### PR TITLE
Added option to configure the printed size ; gzip or actual asset size

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,27 @@
 const AssetSizePlugin = require('./lib/asset-size-plugin')
 
+const defaultPluginOptions = {
+  printGzipSizes: true
+}
+
 module.exports = ({ webpack = config => config, ...nextConfig } = {}) => ({
   // pass nextConfig
   ...nextConfig,
 
   // overwrite webpack config
   webpack: (config, options) => {
+    const { nextSizeConfig = defaultPluginOptions } = nextConfig
+    const { printGzipSizes } = nextSizeConfig
     const { dev, isServer, buildId, config: { distDir } = {} } = options
 
     if (!dev && !isServer) {
-      config.plugins.push(new AssetSizePlugin({ buildId, distDir }))
+      config.plugins.push(
+        new AssetSizePlugin({
+          buildId,
+          distDir,
+          printGzipSizes
+        })
+      )
 
       if (config.output.futureEmitAssets) {
         // next v8 uses `futureEmitAssets` which deactivates asset.size()

--- a/lib/asset-size-plugin.js
+++ b/lib/asset-size-plugin.js
@@ -42,9 +42,10 @@ const filterFiles = filename => {
 }
 
 class AssetsSizePlugin {
-  constructor({ buildId, distDir }) {
+  constructor({ buildId, distDir, printGzipSizes = true }) {
     this.buildId = buildId
     this.distDir = distDir ? pathRelative(process.cwd(), distDir) + '/' : ''
+    this.printGzipSizes = printGzipSizes
   }
 
   formatFilename(rawFilename) {
@@ -92,7 +93,9 @@ class AssetsSizePlugin {
         })
         .map(async filename => {
           const asset = assets[filename]
-          const size = (await gzip(asset.source())).length
+          const size = this.printGzipSizes
+            ? (await gzip(asset.source())).length
+            : asset.source().length
 
           return {
             filename,
@@ -107,7 +110,9 @@ class AssetsSizePlugin {
       ...sizes.map(({ prettySize }) => prettySize.length)
     )
 
-    let message = '\nBrowser assets sizes after gzip:\n\n'
+    let message = this.printGzipSizes
+      ? '\nBrowser assets sizes after gzip:\n\n'
+      : '\nBrowser assets sizes:\n\n'
 
     for (let { filename, size, prettySize } of sizes) {
       const padding = ' '.repeat(longestPrettySize - prettySize.length)

--- a/readme.md
+++ b/readme.md
@@ -16,13 +16,19 @@ yarn add next-size --dev
 
 ### Usage
 
-Edit your next configuration :
+Edit your next configuration and wrap you config with `withSize`.
+Optionnally, you can provide an option to print actual asset sizes (defaults to gzipped sizes).
 
 ```js
 // next.config.js
 const withSize = require('next-size')
 
-module.exports = withSize()
+module.exports = withSize({
+  // NextSizes config is optional
+  nextSizeConfig: {
+    printGzipSizes: true // Defaults to true
+  }
+})
 ```
 
 The size of the assets created will be showed when you run `next-build`


### PR DESCRIPTION
I added an option for the plugin, so we can decide if we want the actual asset size of the gzipped size to be printed.

In my case, I prefer to have the asset size to be printed, because I am working on mobile devices, and JavaScript parsing/execution makes actual asset size more relevant than gzipped size.

Feel free to edit and merge!